### PR TITLE
Update `package-lock.json` and switch submodule to HTTP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/typewriter"]
 	path = lib/typewriter
-	url = git@github.com:taylorhadden/typewriter.git
+	url = https://github.com/taylorhadden/typewriter.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 		},
 		"apps/tangent-electron": {
 			"name": "tangent_electron",
-			"version": "0.7.0-beta.1",
+			"version": "0.8.0-beta.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@such-n-such/tangent-query-parser": "^0.1.0",
@@ -16118,16 +16118,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"packages/tangent-test-workspace-generator": {
-			"version": "0.0.1",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"lorem-ipsum": "^2.0.8",
-				"ts-node": "^10.9.1",
-				"yargs": "^17.7.1"
-			}
 		}
 	}
 }


### PR DESCRIPTION
In order to get Flatpak builds working, I've had to make a few changes.

1. Update `package-lock.json`
2. Switch the Typewriter submodule to HTTP

I've had to switch from SSH because Github doesn't allow pulling from SSH unless you add the machine's SSH key to a Github account. Since the builds will run on Flathub's CI servers, this is not feasible.

In case you need write access to the submodule from the main repo, I recommend using `insteadOf` in your git config.

Example:

```ini
[url "ssh://git@github.com"]
	insteadOf = https://github.com
```

Related to #86