### PR TITLE
Fix wrong Electron version

### DIFF
--- a/apps/tangent-electron/electron-builder.json
+++ b/apps/tangent-electron/electron-builder.json
@@ -4,7 +4,7 @@
 	"copyright": "Copyright © 2022 Taylor Hadden",
 
 	"generateUpdatesFilesForAllChannels": true,
-	"electronVersion": "29.1.4",
+	"electronVersion": "33.0.2",
 
 	"files": [
 		"node_modules/**/*",


### PR DESCRIPTION
The version of Electron in `package-lock.json` has been updated to `33.0.2` in 8906db1ddaedd051f915208dc89088d14b451fc5, but [`electron-builder.json`](apps/tangent-electron/electron-builder.json) still references the old version - `29.1.4`. This breaks offline builds required for #86.

This PR sets `33.0.2` in `electron-builder.json`.