### PR TITLE
Bump Electron to 34.0.0, regenerate package-lock

### DIFF
--- a/apps/tangent-electron/electron-builder.json
+++ b/apps/tangent-electron/electron-builder.json
@@ -4,7 +4,7 @@
 	"copyright": "Copyright © 2022 Taylor Hadden",
 
 	"generateUpdatesFilesForAllChannels": true,
-	"electronVersion": "33.0.2",
+	"electronVersion": "34.0.0",
 
 	"files": [
 		"node_modules/**/*",

--- a/apps/tangent-electron/package.json
+++ b/apps/tangent-electron/package.json
@@ -78,7 +78,7 @@
     "concurrently": "^6.0.2",
     "cross-env": "^7.0.3",
     "css-loader": "^5.0.1",
-    "electron": "^33.0.2",
+    "electron": "^34.0.0",
     "electron-builder": "^24.13.3",
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^28.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 		},
 		"apps/tangent-electron": {
 			"name": "tangent_electron",
-			"version": "0.8.1",
+			"version": "0.8.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@such-n-such/tangent-query-parser": "^0.1.0",
@@ -59,7 +59,7 @@
 				"concurrently": "^6.0.2",
 				"cross-env": "^7.0.3",
 				"css-loader": "^5.0.1",
-				"electron": "^33.0.2",
+				"electron": "^34.0.0",
 				"electron-builder": "^24.13.3",
 				"jest": "^29.6.2",
 				"jest-environment-jsdom": "^28.1.3",
@@ -7339,9 +7339,9 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "33.0.2",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-33.0.2.tgz",
-			"integrity": "sha512-C2WksfP0COsMHbYXSJG68j6S3TjuGDrw/YT42B526yXalIlNQZ2GeAYKryg6AEMkIp3p8TUfDRD0+HyiyCt/nw==",
+			"version": "34.0.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-34.0.0.tgz",
+			"integrity": "sha512-fpaPb0lifoUJ6UJa4Lk8/0B2Ku/xDZWdc1Gkj67jbygTCrvSon0qquju6Ltx1Kz23GRqqlIHXiy9EvrjpY7/Wg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",


### PR DESCRIPTION
Related to #86

https://github.com/electron/electron/issues/43819 indeed seems to have been fixed. I was able to use the Tangent Flatpak on systems where the file picker was previously broken.

I also did a few basic tests (opening the app, loading my workspace) to make sure the new Electron version doesn't break anything major, but you might want to check yourself.