### PR TITLE
Feat: template buttons for creation rule editors

### DIFF
--- a/apps/tangent-electron/src/app/views/creation-rules/CreationRuleEditor.svelte
+++ b/apps/tangent-electron/src/app/views/creation-rules/CreationRuleEditor.svelte
@@ -76,6 +76,18 @@ function templateDependencies(template) {
 	exampleNameMessages = messages
 }
 
+function getNewSelectionStart(selectionStart: number, selectionEnd: number, insertString: string) {
+	if (selectionStart < selectionEnd) {
+		return selectionStart
+	} else {
+		return selectionStart + insertString.length
+	}
+}
+
+function getNewSelectionEnd(selectionStart: number, selectionEnd: number, insertString: string) {
+	return selectionStart + insertString.length
+}
+
 /**
  * Insert the given insertionString into the template at the last-seen selection start position. If the lastSelectionEnd position
  * is unlike the lastSelectionStart position, then the insertion will be made between the two positions and the selected text will be removed.
@@ -91,20 +103,24 @@ const insertTextIntoTemplate: TemplateButtonCallback = function(
 			$nameTemplate = currentText.slice(0, lastSelectionStart) + insertionString + currentText.slice(lastSelectionEnd)
 
 			// give the svelte UI time to redraw things
-			tick()
+			tick().then(() => {
+				console.log(`Selection range was ${lastSelectionStart}, ${lastSelectionEnd}`)
 
-			//set the new selection position after the redraw has happened
-			const newSelectionStart = lastSelectionStart + insertionString.length
-			const newSelectionEnd = newSelectionStart
+				//set the new selection position after the redraw has happened
+				const newSelectionStart = getNewSelectionStart(lastSelectionStart, lastSelectionEnd, insertionString)
+				const newSelectionEnd = getNewSelectionEnd(lastSelectionStart, lastSelectionEnd, insertionString)
 
-			// wanted to maintain the range selection here, but couldn't get the API to behave as expected. Unsure why.
+				// wanted to maintain the range selection here, but couldn't get the API to behave as expected. Unsure why.
 
-			templateInput.focus()
-			templateInput.setSelectionRange(newSelectionStart, newSelectionEnd)
+				templateInput.focus()
+				templateInput.setSelectionRange(newSelectionStart, newSelectionEnd)
 
-			// reset last selection start to 0 - await a new selection start when the user initiates another mousedown on a template component
-			lastSelectionStart = 0
-			lastSelectionEnd = 0
+				console.log(`Attempted to set focus to ${newSelectionStart}, ${newSelectionEnd} with insertion length ${insertionString.length}, got setting ${templateInput.selectionStart}, ${templateInput.selectionEnd}`)
+
+				// reset last selection start to 0 - await a new selection start when the user initiates another mousedown on a template component
+				lastSelectionStart = 0
+				lastSelectionEnd = 0
+			})
 		} else {
 			// user had no focus set, so we're just going to insert at the end
 			$nameTemplate = currentText + insertionString

--- a/apps/tangent-electron/src/app/views/creation-rules/CreationRuleTemplateButton.svelte
+++ b/apps/tangent-electron/src/app/views/creation-rules/CreationRuleTemplateButton.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import {TemplateButtonCallback} from "../../../common/templatebuttons";
+	import {tooltip} from "../../utils/tooltips";
+
+    export let templateText: string;
+	export let saveCurrentSelection;
+	export let insertTemplateText: TemplateButtonCallback;
+
+	// Handler function that calls the prop function
+	function handleClick() {
+		insertTemplateText(templateText);
+	}
+
+	function handleMouseDown() {
+		saveCurrentSelection();
+	}
+</script>
+
+<!--
+@component
+CreationRule TemplateButton is a specific utility component that mainly exists to ensure that what a button *says* it will
+insert and is actually inserted, only has a single source of truth.
+
+This component accepts two callbacks: one to save the current focus, which should fire before the button steals focus from
+the template input (and erases the selection start and end) The other callback is fired when the button has definitely been
+engaged, and follows the TemplateButtonCallback interface to  request insertion of the template string into the Template input.
+-->
+
+<button use:tooltip={`Click to insert template token "${templateText}" into template string`} on:mousedown={handleMouseDown} on:click={handleClick}>
+	{templateText}
+</button>
+

--- a/apps/tangent-electron/src/app/views/editors/NoteEditor/editorModule.ts
+++ b/apps/tangent-electron/src/app/views/editors/NoteEditor/editorModule.ts
@@ -788,7 +788,7 @@ export default function editorModule(editor: Editor, options: {
 		}
 	}
 
-	async function toggleLink(event: ShortcutEvent) {
+	async function toggleLink(event?: ShortcutEvent) {
 		const { doc } = editor
 		const selection = normalizeRange(doc.selection)
 		if (!selection) return
@@ -800,7 +800,7 @@ export default function editorModule(editor: Editor, options: {
 		// No stomping!
 		if (link?.form === 'wiki') return
 
-		event.preventDefault()
+		event?.preventDefault()
 		
 		if (link) {
 			if (link.form === 'raw') {
@@ -918,7 +918,7 @@ export default function editorModule(editor: Editor, options: {
 	 * @param event 
 	 * @param mode 'name' uses the selected text as the name of the note to link to. 'display' uses the selected text as the display text.
 	 */
-	function toggleWikiLink(event: ShortcutEvent, mode: 'name'|'display') {
+	function toggleWikiLink(mode: 'name'|'display', event?: ShortcutEvent) {
 		const { doc } = editor
 		const selection = normalizeRange(doc.selection)
 		if (!selection) return
@@ -930,7 +930,7 @@ export default function editorModule(editor: Editor, options: {
 		// No stomping!
 		if (link?.form === 'md' || link?.form === 'raw') return
 
-		event.preventDefault()
+		event?.preventDefault()
 
 		if (link?.form === 'wiki') {
 			// Remove the link
@@ -1008,42 +1008,44 @@ export default function editorModule(editor: Editor, options: {
 		}
 	}
 
-	function toggleItalic(event: ShortcutEvent) {
+	function toggleItalic(event?: ShortcutEvent) {
 		toggleInlineFormat(
-			event,
 			workspace?.settings?.italicsCharacters.value ?? '_',
-			attr => attr?.italic)
+			attr => attr?.italic,
+			event
+		)
 	}
 
-	function toggleBold(event: ShortcutEvent) {
+	function toggleBold(event?: ShortcutEvent) {
 		return toggleInlineFormat(
-			event,
 			workspace?.settings?.boldCharacters.value ?? '**',
-			attr => attr?.bold)
+			attr => attr?.bold,
+			event
+		)
 	}
 
-	function toggleHightlight(event: ShortcutEvent) {
+	function toggleHightlight(event?: ShortcutEvent) {
 		return toggleInlineFormat(
-			event,
 			'==',
-			attr => attr?.highlight
+			attr => attr?.highlight,
+			event
 		)
 	}
 
-	function toggleInlineCode(event: ShortcutEvent) {
+	function toggleInlineCode(event?: ShortcutEvent) {
 		return toggleInlineFormat(
-			event,
 			'`',
-			attr => attr?.inline_code
+			attr => attr?.inline_code,
+			event
 		)
 	}
 
-	function toggleInlineFormat(event: ShortcutEvent, formattingCharacters: string, predicate: AttributePredicate) {
+	function toggleInlineFormat(formattingCharacters: string, predicate: AttributePredicate, event?: ShortcutEvent) {
 		const { doc } = editor
 		const selection = normalizeRange(doc.selection)
 		if (!selection) return
 		const [at, to] = selection
-		event.preventDefault()
+		event?.preventDefault()
 
 		const formatLength = formattingCharacters.length
 
@@ -1226,18 +1228,18 @@ export default function editorModule(editor: Editor, options: {
 		change.apply()
 	}
 
-	function setHeader(event: ShortcutEvent, level: number) {
+	function setHeader(level: number, event?: ShortcutEvent) {
 		if (level <= 0) return
-		return setLinePrefix(event, repeatString('#', level) + ' ')
+		return setLinePrefix(repeatString('#', level) + ' ', event)
 	}
 
-	function setLinePrefix(event: ShortcutEvent, newPrefix: string) {
+	function setLinePrefix(newPrefix: string, event?: ShortcutEvent) {
 		const { doc } = editor
 		const selection = doc.selection
 		if (!selection) return
 		const [at, to] = doc.selection
 
-		event.preventDefault()
+		event?.preventDefault()
 
 		const lines = doc.getLinesAt(selection)
 		const change = editor.change
@@ -1488,9 +1490,9 @@ export default function editorModule(editor: Editor, options: {
 			case 'Mod+K':
 				return toggleLink(event)
 			case 'Mod+Alt+K':
-				return toggleWikiLink(event, 'name')
+				return toggleWikiLink('name', event)
 			case 'Mod+Alt+Shift+K':
-				return toggleWikiLink(event, 'display')
+				return toggleWikiLink('display', event)
 			case 'Mod+I':
 				return toggleItalic(event)
 			case 'Mod+B':
@@ -1503,19 +1505,19 @@ export default function editorModule(editor: Editor, options: {
 				return toggleLineComment(event)
 
 			case 'Mod+1':
-				return setHeader(event, 1)
+				return setHeader(1, event)
 			case 'Mod+2':
-				return setHeader(event, 2)
+				return setHeader(2, event)
 			case 'Mod+3':
-				return setHeader(event, 3)
+				return setHeader(3, event)
 			case 'Mod+4':
-				return setHeader(event, 4)
+				return setHeader(4, event)
 			case 'Mod+5':
-				return setHeader(event, 5)
+				return setHeader(5, event)
 			case 'Mod+6':
-				return setHeader(event, 6)
+				return setHeader(6, event)
 			case 'Mod+0':
-				return setLinePrefix(event, '')
+				return setLinePrefix('', event)
 
 			case 'Alt+ArrowUp':
 				return shiftGroup(event, 'lines', -1)
@@ -1609,7 +1611,7 @@ export default function editorModule(editor: Editor, options: {
 					label: (link ? 'Remove' : 'Create') + ' Wikilink',
 					accelerator: 'CommandOrControl+Alt+K',
 					click() {
-						toggleWikiLink(new ShortcutEvent('foo'), 'name')
+						toggleWikiLink('name')
 					}
 				})
 			}
@@ -1618,9 +1620,7 @@ export default function editorModule(editor: Editor, options: {
 				linkItems.push({
 					label: (link?.form === 'md' ? 'Remove' : 'Create') + ' Markdown Link',
 					accelerator: 'CommandOrControl+K',
-					click() {
-						toggleLink(new ShortcutEvent('foo'))
-					},
+					click: toggleLink
 				})
 			}
 
@@ -1634,6 +1634,93 @@ export default function editorModule(editor: Editor, options: {
 				menu.push(linkItems[0])
 			}
 		}
+
+		menu.push({
+			label: 'Formatting',
+			submenu: [
+				{
+					id: 'window_toggleBold',
+					label: 'Toggle Bold',
+					accelerator: 'CommandOrControl+B',
+					click: toggleBold
+				},
+				{
+					id: 'window_toggleItalics',
+					label: 'Toggle Italics',
+					accelerator: 'CommandOrControl+I',
+					click: toggleItalic
+				},
+				{
+					id: 'window_toggleHighlight',
+					label: 'Toggle Highlight',
+					accelerator: 'CommandOrControl+=',
+					click: toggleHightlight
+				},
+				{
+					id: 'window_toggleInlineCode',
+					label: 'Toggle Inline Code',
+					accelerator: 'CommandOrControl+\\',
+					click: toggleInlineCode
+				},
+				{ type: 'separator' },
+				{
+					id: 'window_setParagraph',
+					label: 'Paragraph',
+					accelerator: 'CommandOrControl+0',
+					click() {
+						setLinePrefix('')
+					}
+				},
+				{
+					id: 'window_setHeader1',
+					label: 'Header 1',
+					accelerator: 'CommandOrControl+1',
+					click() {
+						setHeader(1)
+					}
+				},
+				{
+					id: 'window_setHeader2',
+					label: 'Header 2',
+					accelerator: 'CommandOrControl+2',
+					click() {
+						setHeader(2)
+					}
+				},
+				{
+					id: 'window_setHeader3',
+					label: 'Header 3',
+					accelerator: 'CommandOrControl+3',
+					click() {
+						setHeader(3)
+					}
+				},
+				{
+					id: 'window_setHeader4',
+					label: 'Header 4',
+					accelerator: 'CommandOrControl+4',
+					click() {
+						setHeader(4)
+					}
+				},
+				{
+					id: 'window_setHeader5',
+					label: 'Header 5',
+					accelerator: 'CommandOrControl+5',
+					click() {
+						setHeader(5)
+					}
+				},
+				{
+					id: 'window_setHeader6',
+					label: 'Header 6',
+					accelerator: 'CommandOrControl+6',
+					click() {
+						setHeader(6)
+					}
+				}
+			]
+		})
 
 		appendContextTemplate(event, menu, 'middle')
 	}

--- a/apps/tangent-electron/src/common/templatebuttons.ts
+++ b/apps/tangent-electron/src/common/templatebuttons.ts
@@ -1,0 +1,9 @@
+/**
+ * The TemplateButtonCallback interface specifies how a Template button will call back to the parent
+ * component that is using this button to offer click-to-insert behavior.
+ *
+ * @param templateText the template text that the button wishes to insert
+ */
+export interface TemplateButtonCallback {
+    (templateText: string): void;
+}


### PR DESCRIPTION
This feature replaces the plain text examples of the template tokens in the Creation Rules explanation guides with buttons. That lets you build up template strings for a creation rule much faster than manual writing or copy-and-pasting, especially if you're inexperienced with the tokens (or don't want to write `%` all the time)

<img width="497" height="430" alt="image" src="https://github.com/user-attachments/assets/50e2ce51-c96e-4b69-85a7-d02373bf2b8b" />

Clicking the buttons inserts one instance of the template token text into the template string. If you have a range selected, that range will be replaced by the template token. These actions will not break focus away from the input, so you can keep typing straight away after you used the token buttons during writing. If you click on the button straight away without ever set focus inside the text input, the token will just be added at the end of the already present string. (Breaking focus and clicking will insert at your last position, because the input is remembered across focus breaks.)

Under the hood this is implemented through a single new component with a special callback. That's only to ensure that there's a single source of truth about what template token a button represents. The Typescript interface for that is a little googled, so it's probably going to need a quality/code conventions check, but I wanted to try. 

I tested all the buttons and behaviors I could see:
- just insert straight away 
- write something and insert
- make forward selection and replace
- make backward selection and replace
- insert something, write, break focus and then insert again

and so far it seems to work out nicely, but I also admit, I am not certain I have enumerated every edge case.

I also followed what accessibility and explanation conventions there appear to be, so there's tooltips on all the buttons that explain what they do. But I also added an explanation to the top of the text box to be sure.

There's two open design questions: 
1. should the design of the template buttons be adjusted in any way? I haven't touched the CSS right now, but their styling *may* want some changes
2. Should the editor always steal focus and set selection to the end if you click the button without having focus on the input component when you click the button? For the moment I've been very minimal with focus stealing. (That said, if you ever wrote something inside the editor, your last selection position isn't 0 and the focus stealing triggers in any case. This may require some more tuning.)
