### PR TITLE
Chore: update tangent-html-to-markdown devDependencies

### DIFF
--- a/packages/tangent-html-to-markdown/package.json
+++ b/packages/tangent-html-to-markdown/package.json
@@ -39,9 +39,9 @@
     "turndown": "^7.1.1"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.6",
-    "jest": "^28.1.3",
-    "jest-environment-jsdom": "^28.1.3",
-    "ts-jest": "^28.0.7"
+    "@types/jest": "^30.0.0",
+    "jest": "^30.0.5",
+    "jest-environment-jsdom": "^30.0.5",
+    "ts-jest": "^29.4.0"
   }
 }


### PR DESCRIPTION
This update let me launch tests with TypeScript 5.