### PR TITLE
Remove jest from tangent-html-to-markdown and tangent-html-to-markdown

### DIFF
--- a/packages/tangent-html-to-markdown/tsconfig.build.json
+++ b/packages/tangent-html-to-markdown/tsconfig.build.json
@@ -6,7 +6,7 @@
 		"target": "ESNext",
 		"moduleResolution": "node",
 		"esModuleInterop": true,
-		"types": ["node", "jest"],
+		"types": ["node"],
 
 		"sourceMap": true,
 		"declaration": true,

--- a/packages/tangent-query-parser/tsconfig.build.json
+++ b/packages/tangent-query-parser/tsconfig.build.json
@@ -6,7 +6,7 @@
 		"target": "ESNext",
 		"moduleResolution": "node",
 		"esModuleInterop": true,
-		"types": ["node", "jest"],
+		"types": ["node"],
 
 		"sourceMap": true,
 		"declaration": true,


### PR DESCRIPTION
Removing jest from tangent-html-to-markdown and tangent-html-to-markdown, I can run tests with no problems.