### PR TITLE
Fix missing <description> tag in metainfo versions

### DIFF
--- a/apps/tangent-electron/build/flatpak/io.github.suchnsuch.Tangent.metainfo.xml
+++ b/apps/tangent-electron/build/flatpak/io.github.suchnsuch.Tangent.metainfo.xml
@@ -88,11 +88,13 @@
 
   <releases>
     <release version="0.10.2" date="2025-09-06">
-      <ul>
-        <li>Pressing escape now dismisses any active annotations or search highlights in a note.</li>
-        <li>Completed or canceled Todos are now no longer crossed out while selected.</li>
-        <li>Fixed an issue that caused scrolling up in the [[Feed Lens]] to jump around obnoxiously.</li>
-      </ul>
+      <description>
+        <ul>
+          <li>Pressing escape now dismisses any active annotations or search highlights in a note.</li>
+          <li>Completed or canceled Todos are now no longer crossed out while selected.</li>
+          <li>Fixed an issue that caused scrolling up in the [[Feed Lens]] to jump around obnoxiously.</li>
+        </ul>
+      </description>
     </release>
     <release version="0.10.1" date="2025-08-23">
       <description>


### PR DESCRIPTION
Related to https://github.com/flathub/io.github.suchnsuch.Tangent/pull/21 - the metainfo file fails validation due to a missing `<description>` tag.

@taylorhadden Can you please either tag 0.10.3 or re-tag 0.10.2 after merging?