### PR TITLE
fixes strange behaviour for RTL where `dir=auto` does not work in card view

### DIFF
--- a/apps/tangent-electron/src/app/views/node-views/CardsView.svelte
+++ b/apps/tangent-electron/src/app/views/node-views/CardsView.svelte
@@ -195,6 +195,8 @@ function updateShowCreateFromHover(event: MouseEvent) {
 
 				padding: .5rem;
 
+				text-align: -webkit-auto; // fixes strange behaviour for RTL where `dir=auto` does not work
+
 				--fontSize: calc(1rem * .8);
 				--headerFontSizeFactor: 2;
 


### PR DESCRIPTION
as mentioned in https://github.com/suchnsuch/Tangent/issues/227#issuecomment-4644782274