### PR TITLE
fix `copy` button for RTL TODO list ( right `LineGutter` )

### DIFF
--- a/apps/tangent-electron/src/app/views/editors/NoteEditor/LineGutter.svelte
+++ b/apps/tangent-electron/src/app/views/editors/NoteEditor/LineGutter.svelte
@@ -30,14 +30,21 @@ function positionOnLine(line: HTMLElement, container: HTMLElement) {
 		placement: side === 'left' ? 'left-start' : 'right-start'
 	}).then(result => {
 		const lineStyle = getComputedStyle(line)
-		const marginLeft = parseFloat(lineStyle.marginLeft)
 		const lineHeight = parseFloat(lineStyle.lineHeight)
 
 		const containerRect = container.getBoundingClientRect()
 		const offset = (lineHeight - containerRect.height) / 2
 
-		container.style.left = result.x - marginLeft + 'px'
 		container.style.top = result.y + offset + 'px'
+
+		if (side === 'left'){
+			const marginLeft = parseFloat(lineStyle.marginLeft)
+			container.style.left = result.x - marginLeft + 'px'
+		}
+		else {
+			const marginRight = parseFloat(lineStyle.marginRight)
+			container.style.left = result.x + marginRight + 'px'
+		}
 	})
 }
 


### PR DESCRIPTION
fix a problem where the `copy` button intersects with the RTL TODO checkbox

## before
<img width="188" height="132" alt="image" src="https://github.com/user-attachments/assets/b5ae5d81-2eea-4f87-ba42-9eeed11b5a14" />

## after 
<img width="188" height="132" alt="image" src="https://github.com/user-attachments/assets/7386fcc7-83b8-44f3-8b2a-83a9bc3add80" />


```md
- [] hello
	- [ ] item 1
	- [ ] item 2
- [ ] سلام
	- [ ] مورد 1
	- [ ] مورد 2
```

--------

https://github.com/suchnsuch/Tangent/pull/392#issuecomment-4785123252