### PR TITLE
add rotate scroll when shift key is pressed for image view

### DIFF
--- a/apps/tangent-electron/src/app/views/node-views/ImageView.svelte
+++ b/apps/tangent-electron/src/app/views/node-views/ImageView.svelte
@@ -32,8 +32,13 @@ function onWheel(event: WheelEvent) {
 	}
 	else if ($zoom !== 1) { // Helps when in tangent view
 		event.preventDefault()
-		$panX = $panX + event.deltaX * -1 * (1/$zoom)
-		$panY = $panY + event.deltaY * -1 * (1/$zoom)
+		
+		// shift key changes direction
+		const dx = event.deltaX * -1 * (1/$zoom)
+		const dy = event.deltaY * -1 * (1/$zoom)
+
+		$panX = $panX + (event.shiftKey ? dy : dx)
+		$panY = $panY + (event.shiftKey ? dx : dy)
 	}
 }
 


### PR DESCRIPTION
Hi again Taylor!

following my changes for PDF (https://github.com/suchnsuch/Tangent/pull/408) I've added `shift` key scroll behavior for image view too. 
this feature is implemented in most softwares and it is specially useful on desktop PC where touch pad is not available.