### PR TITLE
Fix wiki header links with padded labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.DS_Store
 .svelte-kit/
 *.env
 *.tsbuildinfo

--- a/apps/tangent-electron/src/app/model/nodeViewStates/NoteViewState.ts
+++ b/apps/tangent-electron/src/app/model/nodeViewStates/NoteViewState.ts
@@ -270,7 +270,10 @@ export default class NoteViewState implements NodeViewState, LensViewState {
 			annotation.end = link.end
 		}
 		else if (link.content_id) {
-			const idMatch = createContentIdMatcher(link.content_id)
+			const contentId = link.content_id[0] === '^'
+				? link.content_id
+				: safeHeaderLine(link.content_id)
+			const idMatch = createContentIdMatcher(contentId)
 			if (idMatch) {
 				// Look for headers
 				let start = 0

--- a/apps/tangent-electron/src/app/model/nodeViewStates/NoteViewState.ts
+++ b/apps/tangent-electron/src/app/model/nodeViewStates/NoteViewState.ts
@@ -270,10 +270,7 @@ export default class NoteViewState implements NodeViewState, LensViewState {
 			annotation.end = link.end
 		}
 		else if (link.content_id) {
-			const contentId = link.content_id[0] === '^'
-				? link.content_id
-				: safeHeaderLine(link.content_id)
-			const idMatch = createContentIdMatcher(contentId)
+			const idMatch = createContentIdMatcher(link.content_id)
 			if (idMatch) {
 				// Look for headers
 				let start = 0

--- a/apps/tangent-electron/src/common/markdownModel/header.test.ts
+++ b/apps/tangent-electron/src/common/markdownModel/header.test.ts
@@ -8,6 +8,11 @@ describe('Safe characters', () => {
 		expect(header.safeHeaderLine('Header & Stuff')).toEqual('Header & Stuff')
 	})
 
+	it('Should trim surrounding whitespace', () => {
+		expect(header.safeHeaderLine('  My Great Header  ')).toEqual('My Great Header')
+		expect(header.safeHeaderLine('## This Header Rocks!  ')).toEqual('This Header Rocks!')
+	})
+
 	it('Should Remove header formatting', () => {
 		expect(header.safeHeaderLine('## This Header Rocks!')).toEqual('This Header Rocks!')
 	})
@@ -50,4 +55,3 @@ describe('Format stripping', () => {
 	})
 	
 })
-

--- a/apps/tangent-electron/src/common/markdownModel/header.ts
+++ b/apps/tangent-electron/src/common/markdownModel/header.ts
@@ -38,7 +38,7 @@ export function safeHeaderLine(text: string) {
 	text = text.replace(/[^\w\d-_ &%$!]+/g, '')
 
 	// Condense spaces
-	return text.replace(/ +/g, ' ')
+	return text.replace(/ +/g, ' ').trim()
 }
 
 export function parseHeader(char: string, parser: NoteParser): boolean {

--- a/apps/tangent-electron/src/common/markdownModel/links.test.ts
+++ b/apps/tangent-electron/src/common/markdownModel/links.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { StructureType } from 'common/indexing/indexTypes'
 import { createContentIdMatcher, matchMarkdownLink, matchWikiLink } from './links'
+import { safeHeaderLine } from './header'
 
 describe('Wiki Links', () => {
 	it('Should work for the basics', () => {
@@ -370,16 +371,16 @@ describe('Content ID Matching', () => {
 		expect('My Long Header'.match(createContentIdMatcher('my-long_header'))).toBeTruthy()
 	})
 
-	it('Ignores padding around wiki link header ids and headings', () => {
+	it('Matches padded wiki link header ids after header normalization', () => {
 		const link = matchWikiLink('[[note#My Header | label]]')
-		const matcher = createContentIdMatcher(link.content_id)
+		const matcher = createContentIdMatcher(safeHeaderLine(link.content_id))
 
-		expect('My Header'.match(matcher)).toBeTruthy()
-		expect(' My Header '.match(matcher)).toBeTruthy()
+		expect(safeHeaderLine('## My Header').match(matcher)).toBeTruthy()
 	})
 
 	it('Only hits entire names', () => {
 		expect('My Header'.match(createContentIdMatcher('My'))).toBeFalsy()
 		expect('My'.match(createContentIdMatcher('My-header'))).toBeFalsy()
+		expect(' My Header '.match(createContentIdMatcher('My Header'))).toBeFalsy()
 	})
 })

--- a/apps/tangent-electron/src/common/markdownModel/links.test.ts
+++ b/apps/tangent-electron/src/common/markdownModel/links.test.ts
@@ -370,6 +370,14 @@ describe('Content ID Matching', () => {
 		expect('My Long Header'.match(createContentIdMatcher('my-long_header'))).toBeTruthy()
 	})
 
+	it('Ignores padding around wiki link header ids and headings', () => {
+		const link = matchWikiLink('[[note#My Header | label]]')
+		const matcher = createContentIdMatcher(link.content_id)
+
+		expect('My Header'.match(matcher)).toBeTruthy()
+		expect(' My Header '.match(matcher)).toBeTruthy()
+	})
+
 	it('Only hits entire names', () => {
 		expect('My Header'.match(createContentIdMatcher('My'))).toBeFalsy()
 		expect('My'.match(createContentIdMatcher('My-header'))).toBeFalsy()

--- a/apps/tangent-electron/src/common/markdownModel/links.test.ts
+++ b/apps/tangent-electron/src/common/markdownModel/links.test.ts
@@ -371,9 +371,9 @@ describe('Content ID Matching', () => {
 		expect('My Long Header'.match(createContentIdMatcher('my-long_header'))).toBeTruthy()
 	})
 
-	it('Matches padded wiki link header ids after header normalization', () => {
+	it('Trims padded wiki link header ids before matching safe header lines', () => {
 		const link = matchWikiLink('[[note#My Header | label]]')
-		const matcher = createContentIdMatcher(safeHeaderLine(link.content_id))
+		const matcher = createContentIdMatcher(link.content_id)
 
 		expect(safeHeaderLine('## My Header').match(matcher)).toBeTruthy()
 	})

--- a/apps/tangent-electron/src/common/markdownModel/links.ts
+++ b/apps/tangent-electron/src/common/markdownModel/links.ts
@@ -344,15 +344,16 @@ export function resolveLink(store: DefaultIndexStore, link: HrefFormedLink): Tre
 }
 
 export function createContentIdMatcher(contentId: string): RegExp {
-	if (!contentId) return null
-	if (contentId[0] === '^') {
+	const normalizedContentId = contentId?.trim()
+	if (!normalizedContentId) return null
+	if (normalizedContentId[0] === '^') {
 		// ID matches (technically not supported yet)
-		return new RegExp('\^' + contentId.substring(1), 'i')
+		return new RegExp('\^' + normalizedContentId.substring(1), 'i')
 	}
 
 	// Header matches
 	// We want "space-likes" to all be treated the same for cross-compatability & consistency
-	const segments = contentId.split(/[-_ ]+|%20/)
+	const segments = normalizedContentId.split(/[-_ ]+|%20/)
 	return new RegExp('^' + segments.join('([-_ ]|%20)') + '$', 'i')
 }
 

--- a/apps/tangent-electron/src/common/markdownModel/links.ts
+++ b/apps/tangent-electron/src/common/markdownModel/links.ts
@@ -344,17 +344,16 @@ export function resolveLink(store: DefaultIndexStore, link: HrefFormedLink): Tre
 }
 
 export function createContentIdMatcher(contentId: string): RegExp {
-	const normalizedContentId = contentId?.trim()
-	if (!normalizedContentId) return null
-	if (normalizedContentId[0] === '^') {
+	if (!contentId) return null
+	if (contentId[0] === '^') {
 		// ID matches (technically not supported yet)
-		return new RegExp('\^' + normalizedContentId.substring(1), 'i')
+		return new RegExp('\^' + contentId.substring(1), 'i')
 	}
 
 	// Header matches
 	// We want "space-likes" to all be treated the same for cross-compatability & consistency
-	const segments = normalizedContentId.split(/[-_ ]+|%20/)
-	return new RegExp('^ *' + segments.join('([-_ ]|%20)') + ' *$', 'i')
+	const segments = contentId.split(/[-_ ]+|%20/)
+	return new RegExp('^' + segments.join('([-_ ]|%20)') + '$', 'i')
 }
 
 export function linkTextFromLink(link: HrefFormedLink): string {

--- a/apps/tangent-electron/src/common/markdownModel/links.ts
+++ b/apps/tangent-electron/src/common/markdownModel/links.ts
@@ -344,16 +344,17 @@ export function resolveLink(store: DefaultIndexStore, link: HrefFormedLink): Tre
 }
 
 export function createContentIdMatcher(contentId: string): RegExp {
-	if (!contentId) return null
-	if (contentId[0] === '^') {
+	const normalizedContentId = contentId?.trim()
+	if (!normalizedContentId) return null
+	if (normalizedContentId[0] === '^') {
 		// ID matches (technically not supported yet)
-		return new RegExp('\^' + contentId.substring(1), 'i')
+		return new RegExp('\^' + normalizedContentId.substring(1), 'i')
 	}
 
 	// Header matches
 	// We want "space-likes" to all be treated the same for cross-compatability & consistency
-	const segments = contentId.split(/[-_ ]+|%20/)
-	return new RegExp('^' + segments.join('([-_ ]|%20)') + '$', 'i')
+	const segments = normalizedContentId.split(/[-_ ]+|%20/)
+	return new RegExp('^ *' + segments.join('([-_ ]|%20)') + ' *$', 'i')
 }
 
 export function linkTextFromLink(link: HrefFormedLink): string {


### PR DESCRIPTION
Closes #417.

## Summary

- Trim surrounding whitespace from content IDs inside `createContentIdMatcher()` before the existing block/header matching branches.
- Keep `NoteViewState` passing the parsed `link.content_id` directly to the matcher; use `safeHeaderLine()` only for actual Markdown header text.
- Preserve strict, whole-header `^...$` matching without broadening the regex to surrounding whitespace.
- Add regression coverage for `[[note#My Header | label]]`, header-line trimming, and exact matcher boundaries.
- Ignore macOS `.DS_Store` metadata.

## Root cause

`matchWikiLink` intentionally preserves the source text and returns `My Header ` for the content ID in the reported example. Splitting that raw value produced an empty trailing segment, which made the matcher require a separator after the actual header text.

`createContentIdMatcher()` now trims the lookup ID before building its existing strict matcher. `NoteViewState` passes `link.content_id` directly, while the actual Markdown heading is converted with `safeHeaderLine()`.

## Validation

- Focused header/link tests — 43 passed
- `npx vitest run` — 522 passed, 13 skipped
- `npm run build` — passed
- `git diff --check` — passed
