### PR TITLE
force textarea only to grow vertically

### DIFF
--- a/apps/tangent-electron/src/app/style/input.scss
+++ b/apps/tangent-electron/src/app/style/input.scss
@@ -50,6 +50,7 @@ input[type="number"] {
 textarea {
 	color: var(--textColor);
 	background-color: var(--buttonBackgroundColor);
+	resize: vertical;
 }
 
 .dark {


### PR DESCRIPTION
it prevents issues like this to break the UI:

<img width="536" height="521" alt="image" src="https://github.com/user-attachments/assets/5822768c-b532-4b2a-9ac7-8a5f3f1c7970" />
