### PR TITLE
Show the new-note destination in command tooltips

### DIFF
--- a/apps/tangent-electron/src/app/model/commands/CreateNewFile.test.ts
+++ b/apps/tangent-electron/src/app/model/commands/CreateNewFile.test.ts
@@ -3,16 +3,31 @@ import CreateNewFileCommand, { type CreateNewFileCommandContext } from './Create
 import type { Workspace } from '..'
 import IndexTreeStore from 'common/indexing/IndexTreeStore'
 import { knownExtensions } from 'common/fileExtensions'
+import type { TreeNode } from 'common/trees'
 
 describe('Extension auto inclusion', () => {
 
+	const unicodeFolder: TreeNode = {
+		name: '研究',
+		path: 'some/root/Ideas/研究',
+		depth: 3,
+		fileType: 'folder',
+		children: []
+	}
+	const ideasFolder: TreeNode = {
+		name: 'Ideas',
+		path: 'some/root/Ideas',
+		depth: 2,
+		fileType: 'folder',
+		children: [unicodeFolder]
+	}
 	const directoryStore = new IndexTreeStore({
 		files: {
 			name: 'root',
 			path: 'some/root',
 			depth: 1,
 			fileType: 'folder',
-			children: []
+			children: [ideasFolder]
 		},
 		tags: {
 			path: '',
@@ -21,17 +36,20 @@ describe('Extension auto inclusion', () => {
 			fileType: ''
 		}
 	})
+	const effects = { navigation: 0, modal: 0 }
 
-	const workspace = {
+	const workspace: Workspace = Object.assign(Object.create(null), {
 		directoryStore,
+		navigateTo: () => effects.navigation++,
 		viewState: {
+			modal: { push: () => effects.modal++ },
 			directoryView: {
 				selection: {
 					value: []
 				}
 			}
 		}
-	} as Workspace
+	})
 
 	const command = new CreateNewFileCommand(workspace)
 	// Expose the private function type-safely
@@ -108,5 +126,51 @@ describe('Extension auto inclusion', () => {
 			extension: '.md',
 			creationMode: undefined
 		})
+	})
+
+	it('Describes the default, selected, nested, and Unicode destinations', () => {
+		const selection = workspace.viewState.directoryView.selection
+		selection.value = []
+		expect(command.getTooltip()).toContain('Destination: Workspace Root')
+
+		selection.value = [unicodeFolder]
+		expect(command.getTooltip()).toContain('Destination: Ideas/研究')
+	})
+
+	it('Does not claim invalid destinations from reserved or invalid inputs', () => {
+		workspace.viewState.directoryView.selection.value = [{
+			name: 'private', path: 'some/root/.tangent/private', depth: 3, fileType: 'folder'
+		}]
+		expect(command.getTooltip()).toContain('Destination: Workspace Root')
+		expect(command.getTooltip({ relativePath: 'CON/New Note.md' })).toBe('Creates a new note')
+	})
+
+	it('Updates the destination for path and explicit-folder contexts', () => {
+		workspace.viewState.directoryView.selection.value = [unicodeFolder]
+		expect(command.getTooltip({ relativePath: 'Projects/Long Term/New Note.md' }))
+			.toContain('Destination: Projects/Long Term')
+		expect(command.getTooltip({ folder: ideasFolder }))
+			.toContain('Destination: Ideas')
+	})
+
+	it('Preserves rule descriptions and resolves rule destination precedence', () => {
+		const context: CreateNewFileCommandContext = {
+			folder: ideasFolder,
+			path: 'some/root/Other/New Note.md',
+			rule: {
+				name: 'Journal', nameTemplate: 'Daily', folder: 'Journal', contentTemplate: '',
+				mode: 'create', description: 'A custom journal description'
+			}
+		}
+		const before = structuredClone(context)
+		const beforeSelection = workspace.viewState.directoryView.selection.value
+		const beforeEffects = { ...effects }
+		const tooltip = command.getTooltip(context)
+		expect(tooltip).toContain('A custom journal description')
+		expect(tooltip).toContain('Destination: Ideas')
+		expect(command.getTooltip(context)).toBe(tooltip)
+		expect(context).toEqual(before)
+		expect(workspace.viewState.directoryView.selection.value).toBe(beforeSelection)
+		expect(effects).toEqual(beforeEffects)
 	})
 })

--- a/apps/tangent-electron/src/app/model/commands/CreateNewFile.test.ts
+++ b/apps/tangent-electron/src/app/model/commands/CreateNewFile.test.ts
@@ -4,30 +4,33 @@ import type { Workspace } from '..'
 import IndexTreeStore from 'common/indexing/IndexTreeStore'
 import { knownExtensions } from 'common/fileExtensions'
 import type { TreeNode } from 'common/trees'
+import type { CreationRuleDefinition } from 'common/settings/CreationRule'
 
 describe('Extension auto inclusion', () => {
 
-	const unicodeFolder: TreeNode = {
-		name: '研究',
-		path: 'some/root/Ideas/研究',
-		depth: 3,
-		fileType: 'folder',
-		children: []
-	}
-	const ideasFolder: TreeNode = {
-		name: 'Ideas',
-		path: 'some/root/Ideas',
-		depth: 2,
-		fileType: 'folder',
-		children: [unicodeFolder]
-	}
 	const directoryStore = new IndexTreeStore({
 		files: {
 			name: 'root',
 			path: 'some/root',
 			depth: 1,
 			fileType: 'folder',
-			children: [ideasFolder]
+			children: [
+				{
+					name: 'Ideas',
+					path: 'some/root/Ideas',
+					depth: 2,
+					fileType: 'folder',
+					children: [
+						{
+							name: '研究',
+							path: 'some/root/Ideas/研究',
+							depth: 3,
+							fileType: 'folder',
+							children: []
+						}
+					]
+				}
+			]
 		},
 		tags: {
 			path: '',
@@ -36,20 +39,23 @@ describe('Extension auto inclusion', () => {
 			fileType: ''
 		}
 	})
-	const effects = { navigation: 0, modal: 0 }
+	const ideasFolder = directoryStore.files.children[0]
+	const unicodeFolder = ideasFolder.children[0]
 
-	const workspace: Workspace = Object.assign(Object.create(null), {
+	// Counts the side effects a tooltip must never cause
+	const effects = { modal: 0 }
+	// `unknown` first: the stub only implements the members these tests reach
+	const workspace = {
 		directoryStore,
-		navigateTo: () => effects.navigation++,
 		viewState: {
 			modal: { push: () => effects.modal++ },
 			directoryView: {
 				selection: {
-					value: []
+					value: [] as TreeNode[]
 				}
 			}
 		}
-	})
+	} as unknown as Workspace
 
 	const command = new CreateNewFileCommand(workspace)
 	// Expose the private function type-safely
@@ -131,26 +137,36 @@ describe('Extension auto inclusion', () => {
 	it('Describes the default, selected, nested, and Unicode destinations', () => {
 		const selection = workspace.viewState.directoryView.selection
 		selection.value = []
-		expect(command.getTooltip()).toContain('Destination: Workspace Root')
+		expect(command.getTooltip()).toBe('Creates a new note in the root of the workspace.')
 
 		selection.value = [unicodeFolder]
-		expect(command.getTooltip()).toContain('Destination: Ideas/研究')
+		expect(command.getTooltip()).toBe('Creates a new note in Ideas/研究.')
 	})
 
 	it('Does not claim invalid destinations from reserved or invalid inputs', () => {
 		workspace.viewState.directoryView.selection.value = [{
 			name: 'private', path: 'some/root/.tangent/private', depth: 3, fileType: 'folder'
 		}]
-		expect(command.getTooltip()).toContain('Destination: Workspace Root')
+		expect(command.getTooltip()).toBe('Creates a new note in the root of the workspace.')
 		expect(command.getTooltip({ relativePath: 'CON/New Note.md' })).toBe('Creates a new note')
 	})
 
 	it('Updates the destination for path and explicit-folder contexts', () => {
 		workspace.viewState.directoryView.selection.value = [unicodeFolder]
 		expect(command.getTooltip({ relativePath: 'Projects/Long Term/New Note.md' }))
-			.toContain('Destination: Projects/Long Term')
+			.toBe('Creates a new note in Projects/Long Term.')
 		expect(command.getTooltip({ folder: ideasFolder }))
-			.toContain('Destination: Ideas')
+			.toBe('Creates a new note in Ideas.')
+	})
+
+	it('Names the rule when it has no description of its own', () => {
+		workspace.viewState.directoryView.selection.value = []
+		expect(command.getTooltip({
+			rule: {
+				name: 'Journal', nameTemplate: 'Daily', folder: 'Journal', contentTemplate: '',
+				mode: 'create', description: ''
+			}
+		})).toBe('Creates a new Journal in Journal.')
 	})
 
 	it('Preserves rule descriptions and resolves rule destination precedence', () => {
@@ -171,6 +187,33 @@ describe('Extension auto inclusion', () => {
 		expect(command.getTooltip(context)).toBe(tooltip)
 		expect(context).toEqual(before)
 		expect(workspace.viewState.directoryView.selection.value).toBe(beforeSelection)
+		expect(effects).toEqual(beforeEffects)
+	})
+
+	it('Never prompts for a name while building a tooltip', () => {
+		workspace.viewState.directoryView.selection.value = []
+		const rule: CreationRuleDefinition = {
+			name: 'Meeting', nameTemplate: 'Meetings/%name%', folder: 'Notes',
+			contentTemplate: '', mode: 'create', description: ''
+		}
+		const beforeEffects = { ...effects }
+		expect(command.getTooltip({ rule })).toBe('Creates a new Meeting in Notes/Meetings.')
+		expect(effects).toEqual(beforeEffects)
+
+		// The same rule through the interactive path still asks for the name
+		resolveContext({ rule })
+		expect(effects.modal).toBe(beforeEffects.modal + 1)
+	})
+
+	it('Claims no destination when the typed name would choose the folder', () => {
+		workspace.viewState.directoryView.selection.value = []
+		const beforeEffects = { ...effects }
+		expect(command.getTooltip({
+			rule: {
+				name: 'Entry', nameTemplate: '%name%/Entry', folder: 'Notes',
+				contentTemplate: '', mode: 'create', description: ''
+			}
+		})).toBe('Creates a new Entry')
 		expect(effects).toEqual(beforeEffects)
 	})
 })

--- a/apps/tangent-electron/src/app/model/commands/CreateNewFile.test.ts
+++ b/apps/tangent-electron/src/app/model/commands/CreateNewFile.test.ts
@@ -140,7 +140,7 @@ describe('Extension auto inclusion', () => {
 		expect(command.getTooltip()).toBe('Creates a new note in the root of the workspace.')
 
 		selection.value = [unicodeFolder]
-		expect(command.getTooltip()).toBe('Creates a new note in Ideas/研究.')
+		expect(command.getTooltip()).toBe('Creates a new note in "Ideas/研究".')
 	})
 
 	it('Does not claim invalid destinations from reserved or invalid inputs', () => {
@@ -148,15 +148,15 @@ describe('Extension auto inclusion', () => {
 			name: 'private', path: 'some/root/.tangent/private', depth: 3, fileType: 'folder'
 		}]
 		expect(command.getTooltip()).toBe('Creates a new note in the root of the workspace.')
-		expect(command.getTooltip({ relativePath: 'CON/New Note.md' })).toBe('Creates a new note')
+		expect(command.getTooltip({ relativePath: 'CON/New Note.md' })).toBe('Creates a new note.')
 	})
 
 	it('Updates the destination for path and explicit-folder contexts', () => {
 		workspace.viewState.directoryView.selection.value = [unicodeFolder]
 		expect(command.getTooltip({ relativePath: 'Projects/Long Term/New Note.md' }))
-			.toBe('Creates a new note in Projects/Long Term.')
+			.toBe('Creates a new note in "Projects/Long Term".')
 		expect(command.getTooltip({ folder: ideasFolder }))
-			.toBe('Creates a new note in Ideas.')
+			.toBe('Creates a new note in "Ideas".')
 	})
 
 	it('Names the rule when it has no description of its own', () => {
@@ -166,7 +166,7 @@ describe('Extension auto inclusion', () => {
 				name: 'Journal', nameTemplate: 'Daily', folder: 'Journal', contentTemplate: '',
 				mode: 'create', description: ''
 			}
-		})).toBe('Creates a new Journal in Journal.')
+		})).toBe('Creates a new Journal in "Journal".')
 	})
 
 	it('Preserves rule descriptions and resolves rule destination precedence', () => {
@@ -182,8 +182,7 @@ describe('Extension auto inclusion', () => {
 		const beforeSelection = workspace.viewState.directoryView.selection.value
 		const beforeEffects = { ...effects }
 		const tooltip = command.getTooltip(context)
-		expect(tooltip).toContain('A custom journal description')
-		expect(tooltip).toContain('Destination: Ideas')
+		expect(tooltip).toBe('A custom journal description\nDestination: "Ideas".')
 		expect(command.getTooltip(context)).toBe(tooltip)
 		expect(context).toEqual(before)
 		expect(workspace.viewState.directoryView.selection.value).toBe(beforeSelection)
@@ -197,7 +196,7 @@ describe('Extension auto inclusion', () => {
 			contentTemplate: '', mode: 'create', description: ''
 		}
 		const beforeEffects = { ...effects }
-		expect(command.getTooltip({ rule })).toBe('Creates a new Meeting in Notes/Meetings.')
+		expect(command.getTooltip({ rule })).toBe('Creates a new Meeting in "Notes/Meetings".')
 		expect(effects).toEqual(beforeEffects)
 
 		// The same rule through the interactive path still asks for the name
@@ -205,15 +204,24 @@ describe('Extension auto inclusion', () => {
 		expect(effects.modal).toBe(beforeEffects.modal + 1)
 	})
 
-	it('Claims no destination when the typed name would choose the folder', () => {
+	it('Names the folder the template fixes when the typed name adds more', () => {
 		workspace.viewState.directoryView.selection.value = []
 		const beforeEffects = { ...effects }
+		// "%name%/Entry" puts the file in Notes/<typed name>, so "Notes" is the
+		// deepest folder that is known before the name is typed
 		expect(command.getTooltip({
 			rule: {
 				name: 'Entry', nameTemplate: '%name%/Entry', folder: 'Notes',
 				contentTemplate: '', mode: 'create', description: ''
 			}
-		})).toBe('Creates a new Entry')
+		})).toBe('Creates a new Entry in "Notes".')
+		// The segments before the token are still fixed and are still named
+		expect(command.getTooltip({
+			rule: {
+				name: 'Entry', nameTemplate: 'Archive/%name%/Entry', folder: 'Notes',
+				contentTemplate: '', mode: 'create', description: ''
+			}
+		})).toBe('Creates a new Entry in "Notes/Archive".')
 		expect(effects).toEqual(beforeEffects)
 	})
 })

--- a/apps/tangent-electron/src/app/model/commands/CreateNewFile.ts
+++ b/apps/tangent-electron/src/app/model/commands/CreateNewFile.ts
@@ -188,8 +188,8 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 
 				// When looking at a folder, create items within the folder
 				let folder = item.fileType === 'folder' ? item : directoryStore.getParent(item)
-				// A parentless item cannot contribute a folder. execute() has always thrown
-				// on this; only the side-effect-free path skips it.
+				// A parentless item cannot contribute a folder. Only the side-effect-free
+				// path skips it; execute() keeps whatever it does with one today.
 				if (!interactive && !folder) continue
 
 				if (!deepestFolder || deepestFolder.depth > folder.depth) {

--- a/apps/tangent-electron/src/app/model/commands/CreateNewFile.ts
+++ b/apps/tangent-electron/src/app/model/commands/CreateNewFile.ts
@@ -375,12 +375,63 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 		return 'Create New Note'
 	}
 
-	getTooltip(context: CreateNewFileCommandContext) {
-		const rule = context?.rule
+	private resolveTooltipFolder(context?: CreateNewFileCommandContext) {
+		let { rule, path, relativePath, folder, name } = context || {}
+		const { directoryStore, viewState } = this.workspace
+		let folderPath = folder ? directoryStore.pathToRelativePath(folder.path) : false
+
 		if (rule) {
-			const description = rawOrStoreValue(rule.description)
-			return description || 'Creates a new ' + rawOrStoreValue(rule.name)
+			const ruleFolder = rawOrStoreValue(rule.folder)
+			if (name) {
+				relativePath = paths.join(folderPath || ruleFolder, name + '.md')
+			}
+			else {
+				folderPath = folderPath || ruleFolder
+				relativePath = undefined
+			}
 		}
-		return 'Creates a new note'
+
+		if (path && !relativePath && !rule) {
+			const result = directoryStore.pathToRelativePath(path)
+			if (result !== false) relativePath = result
+		}
+		if (relativePath) {
+			const validatedPath = validatePath(relativePath)
+			if (!validatedPath) return undefined
+			folderPath = paths.dirname(validatedPath)
+		}
+
+		if (folderPath === false) {
+			let deepestFolder: TreeNode = null
+			for (const item of viewState?.directoryView?.selection?.value ?? []) {
+				if (item.path.includes('.tangent')) continue
+				const selectedFolder = item.fileType === 'folder' ? item : directoryStore.getParent(item)
+				if (selectedFolder && (!deepestFolder || deepestFolder.depth > selectedFolder.depth)) {
+					deepestFolder = selectedFolder
+				}
+			}
+			folderPath = directoryStore.pathToRelativePath((deepestFolder || directoryStore.files).path)
+		}
+
+		if (!rule && !path && !relativePath && name) {
+			folderPath = paths.dirname(paths.join(folderPath || '', name))
+		}
+		return folderPath
+	}
+
+	getTooltip(context?: CreateNewFileCommandContext) {
+		const rule = context?.rule
+		let description: string
+		if (rule) {
+			description = rawOrStoreValue(rule.description) || 'Creates a new ' + rawOrStoreValue(rule.name)
+		}
+		else {
+			description = 'Creates a new note'
+		}
+
+		const folder = this.resolveTooltipFolder(context)
+		if (folder === undefined || folder === false) return description
+		const destination = !folder || folder === '.' ? 'Workspace Root' : folder
+		return `${description}\nDestination: ${destination}`
 	}
 }

--- a/apps/tangent-electron/src/app/model/commands/CreateNewFile.ts
+++ b/apps/tangent-electron/src/app/model/commands/CreateNewFile.ts
@@ -77,7 +77,14 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 		return existingNode instanceof File
 	}
 
-	private resolveContext(context: CreateNewFileCommandContext): CreationValues {
+	/**
+	 * Resolves the values a context would create a file with.
+	 * Pass `interactive: false` to resolve without side effects: the naming dialog is
+	 * never pushed and an unresolvable context returns `undefined` instead of throwing.
+	 */
+	private resolveContext(context: CreateNewFileCommandContext, options?: { interactive?: boolean }): CreationValues {
+
+		const interactive = options?.interactive ?? true
 
 		let { rule, path, relativePath, folder, name, extension, updateSelection, creationMode } = context || {}
 		const { directoryStore, viewState } = this.workspace
@@ -99,16 +106,26 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 					name = nameResult
 				}
 				else if (nameResult !== null) {
-					const { preName, postName } = nameResult
+					if (!interactive) {
+						// Resolving for a preview, so the typed name is unknown. Anything
+						// after the token would turn that name into a folder, and no
+						// destination can be claimed; otherwise the folder is fixed by the
+						// template and a placeholder name resolves it.
+						if (/[\\/]/.test(nameResult.postName)) return
+						name = nameFromRule(rule, 'New Note') as string
+					}
+					else {
+						const { preName, postName } = nameResult
 
-					this.workspace.viewState.modal.push(CreateFileDialog, {
-						title: 'Create New ' + rule.name,
-						preName,
-						postName,
-						context
-					})
-					// The dialog will handle the rest
-					return
+						this.workspace.viewState.modal.push(CreateFileDialog, {
+							title: 'Create New ' + rule.name,
+							preName,
+							postName,
+							context
+						})
+						// The dialog will handle the rest
+						return
+					}
 				}
 				else {
 					// Fall back to the default naming flow
@@ -138,6 +155,7 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 		if (relativePath) {
 			const validatedPath = validatePath(relativePath)
 			if (!validatedPath) {
+				if (!interactive) return
 				throw new Error(`Could not create file. "${relativePath}" is invalid and could not be made valid.`)
 			}
 			relativePath = validatedPath
@@ -170,6 +188,9 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 
 				// When looking at a folder, create items within the folder
 				let folder = item.fileType === 'folder' ? item : directoryStore.getParent(item)
+				// A parentless item cannot contribute a folder. execute() has always thrown
+				// on this; only the side-effect-free path skips it.
+				if (!interactive && !folder) continue
 
 				if (!deepestFolder || deepestFolder.depth > folder.depth) {
 					deepestFolder = folder
@@ -182,6 +203,7 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 
 			folderPath = directoryStore.pathToRelativePath(deepestFolder.path)
 			if (folderPath === false) {
+				if (!interactive) return
 				throw new Error('A relative folder path could not be determined! This should not happen by this point.')
 			}
 		}
@@ -375,63 +397,22 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 		return 'Create New Note'
 	}
 
-	private resolveTooltipFolder(context?: CreateNewFileCommandContext) {
-		let { rule, path, relativePath, folder, name } = context || {}
-		const { directoryStore, viewState } = this.workspace
-		let folderPath = folder ? directoryStore.pathToRelativePath(folder.path) : false
-
-		if (rule) {
-			const ruleFolder = rawOrStoreValue(rule.folder)
-			if (name) {
-				relativePath = paths.join(folderPath || ruleFolder, name + '.md')
-			}
-			else {
-				folderPath = folderPath || ruleFolder
-				relativePath = undefined
-			}
-		}
-
-		if (path && !relativePath && !rule) {
-			const result = directoryStore.pathToRelativePath(path)
-			if (result !== false) relativePath = result
-		}
-		if (relativePath) {
-			const validatedPath = validatePath(relativePath)
-			if (!validatedPath) return undefined
-			folderPath = paths.dirname(validatedPath)
-		}
-
-		if (folderPath === false) {
-			let deepestFolder: TreeNode = null
-			for (const item of viewState?.directoryView?.selection?.value ?? []) {
-				if (item.path.includes('.tangent')) continue
-				const selectedFolder = item.fileType === 'folder' ? item : directoryStore.getParent(item)
-				if (selectedFolder && (!deepestFolder || deepestFolder.depth > selectedFolder.depth)) {
-					deepestFolder = selectedFolder
-				}
-			}
-			folderPath = directoryStore.pathToRelativePath((deepestFolder || directoryStore.files).path)
-		}
-
-		if (!rule && !path && !relativePath && name) {
-			folderPath = paths.dirname(paths.join(folderPath || '', name))
-		}
-		return folderPath
-	}
-
 	getTooltip(context?: CreateNewFileCommandContext) {
 		const rule = context?.rule
-		let description: string
-		if (rule) {
-			description = rawOrStoreValue(rule.description) || 'Creates a new ' + rawOrStoreValue(rule.name)
-		}
-		else {
-			description = 'Creates a new note'
-		}
+		const description = rule ? rawOrStoreValue(rule.description) : undefined
+		const subject = rule ? 'a new ' + rawOrStoreValue(rule.name) : 'a new note'
 
-		const folder = this.resolveTooltipFolder(context)
-		if (folder === undefined || folder === false) return description
-		const destination = !folder || folder === '.' ? 'Workspace Root' : folder
-		return `${description}\nDestination: ${destination}`
+		const values = this.resolveContext(context ?? {}, { interactive: false })
+		if (!values) return description || 'Creates ' + subject
+
+		const { folderPath } = values
+		const destination = !folderPath || folderPath === '.'
+			? 'the root of the workspace'
+			: folderPath
+
+		if (description) {
+			return `${description}\nDestination: ${destination}`
+		}
+		return `Creates ${subject} in ${destination}.`
 	}
 }

--- a/apps/tangent-electron/src/app/model/commands/CreateNewFile.ts
+++ b/apps/tangent-electron/src/app/model/commands/CreateNewFile.ts
@@ -107,12 +107,14 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 				}
 				else if (nameResult !== null) {
 					if (!interactive) {
-						// Resolving for a preview, so the typed name is unknown. Anything
-						// after the token would turn that name into a folder, and no
-						// destination can be claimed; otherwise the folder is fixed by the
-						// template and a placeholder name resolves it.
-						if (/[\\/]/.test(nameResult.postName)) return
-						name = nameFromRule(rule, 'New Note') as string
+						// Resolving for a preview, so the typed name is unknown and a
+						// placeholder stands in for it. A separator after the token would
+						// make the typed name a folder; dropping that suffix resolves to
+						// the deepest folder the template still fixes.
+						const { preName, postName } = nameResult
+						name = /[\\/]/.test(postName)
+							? preName + 'New Note'
+							: preName + 'New Note' + postName
 					}
 					else {
 						const { preName, postName } = nameResult
@@ -188,8 +190,9 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 
 				// When looking at a folder, create items within the folder
 				let folder = item.fileType === 'folder' ? item : directoryStore.getParent(item)
-				// A parentless item cannot contribute a folder. Only the side-effect-free
-				// path skips it; execute() keeps whatever it does with one today.
+				// `getParent()` misses for a node the store holds no parent entry for:
+				// a root, or one removed since it was selected. Reading `.depth` off
+				// that throws, which a tooltip must not do.
 				if (!interactive && !folder) continue
 
 				if (!deepestFolder || deepestFolder.depth > folder.depth) {
@@ -403,15 +406,15 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 		const subject = rule ? 'a new ' + rawOrStoreValue(rule.name) : 'a new note'
 
 		const values = this.resolveContext(context ?? {}, { interactive: false })
-		if (!values) return description || 'Creates ' + subject
+		if (!values) return description || `Creates ${subject}.`
 
 		const { folderPath } = values
 		const destination = !folderPath || folderPath === '.'
 			? 'the root of the workspace'
-			: folderPath
+			: `"${folderPath}"`
 
 		if (description) {
-			return `${description}\nDestination: ${destination}`
+			return `${description}\nDestination: ${destination}.`
 		}
 		return `Creates ${subject} in ${destination}.`
 	}

--- a/apps/tangent-electron/src/app/model/commands/CreateNewFile.ts
+++ b/apps/tangent-electron/src/app/model/commands/CreateNewFile.ts
@@ -190,9 +190,9 @@ export default class CreateNewFileCommand extends WorkspaceCommand {
 
 				// When looking at a folder, create items within the folder
 				let folder = item.fileType === 'folder' ? item : directoryStore.getParent(item)
-				// `getParent()` misses for a node the store holds no parent entry for:
-				// a root, or one removed since it was selected. Reading `.depth` off
-				// that throws, which a tooltip must not do.
+				// A non-folder item the store has no parent entry for -- one removed
+				// since it was selected -- leaves `folder` undefined, and the next
+				// line reads `.depth` off it. A tooltip skips it instead.
 				if (!interactive && !folder) continue
 
 				if (!deepestFolder || deepestFolder.depth > folder.depth) {


### PR DESCRIPTION
Resolves the Create New Note tooltip destination from explicit, rule, path, or selected-folder context without invoking creation preparation, while retaining custom rule descriptions. Adds focused regression coverage for default, nested, invalid, transition, purity, repeated-read, Unicode, and full-path behavior.

Tests, from `apps/tangent-electron`:

- `npx vitest run src/app/model/commands/CreateNewFile.test.ts` — 13 passed
- `npx tsc --noEmit -p tsconfig.json` — no output, exit 0

`npx vitest run --project tangent-electron-unit-core --project tangent-electron-unit-web` is unchanged by this branch: run once at its head and once with the two changed files checked out at the base, both report `Test Files 9 failed | 28 passed | 1 skipped (38)` and `Tests 3 failed | 320 passed | 12 skipped (335)`. That is not a clean run and I am not claiming one — the 3 failing tests are `paths.test.ts` `resolve()` cases, and 8 of the 9 failing files never collect, because `@such-n-such/tangent-query-parser/lib/types` is not built in my checkout.
