### PR TITLE
add preview for copy path commands as `tooltip`

### DIFF
--- a/apps/tangent-electron/src/app/model/commands/CopyPath.ts
+++ b/apps/tangent-electron/src/app/model/commands/CopyPath.ts
@@ -6,8 +6,8 @@ interface CopyPathCommandContext extends CommandContext {
 	node: TreeNode
 }
 
-function copyPathTooltip(path: string): string {
-	return `Copies "${path}" to the clipboard`
+function copyTooltip(what: string): string {
+	return `Copies "${what}" to the clipboard`
 }
 
 export class CopyAbsolutePathCommand extends WorkspaceCommand {
@@ -38,7 +38,7 @@ export class CopyAbsolutePathCommand extends WorkspaceCommand {
 	getTooltip(context?: CopyPathCommandContext) {
 		const node = this.resolveNode(context)
 		if (node) {
-			return copyPathTooltip(this.getPath(node))
+			return copyTooltip(this.getPath(node))
 		}
 	}
 }
@@ -74,7 +74,7 @@ export class CopyRelativePathCommand extends WorkspaceCommand {
 	getTooltip(context?: CopyPathCommandContext) {
 		const node = this.resolveNode(context)
 		if (node) {
-			return copyPathTooltip(this.getPath(node))
+			return copyTooltip(this.getPath(node))
 		}
 	}
 }

--- a/apps/tangent-electron/src/app/model/commands/CopyPath.ts
+++ b/apps/tangent-electron/src/app/model/commands/CopyPath.ts
@@ -6,6 +6,10 @@ interface CopyPathCommandContext extends CommandContext {
 	node: TreeNode
 }
 
+function copyPathTooltip(path: string): string {
+	return `Copies "${path}" to the clipboard`
+}
+
 export class CopyAbsolutePathCommand extends WorkspaceCommand {
 
 	resolveNode(context?: CopyPathCommandContext) {
@@ -34,7 +38,7 @@ export class CopyAbsolutePathCommand extends WorkspaceCommand {
 	getTooltip(context?: CopyPathCommandContext) {
 		const node = this.resolveNode(context)
 		if (node) {
-			return this.getPath(node)
+			return copyPathTooltip(this.getPath(node))
 		}
 	}
 }
@@ -70,7 +74,7 @@ export class CopyRelativePathCommand extends WorkspaceCommand {
 	getTooltip(context?: CopyPathCommandContext) {
 		const node = this.resolveNode(context)
 		if (node) {
-			return this.getPath(node)
+			return copyPathTooltip(this.getPath(node))
 		}
 	}
 }

--- a/apps/tangent-electron/src/app/model/commands/CopyPath.ts
+++ b/apps/tangent-electron/src/app/model/commands/CopyPath.ts
@@ -16,15 +16,26 @@ export class CopyAbsolutePathCommand extends WorkspaceCommand {
 		return this.resolveNode(context) != null
 	}
 
+	getPath(node: TreeNode): string {
+		return node.path
+	}
+
 	execute(context?: CopyPathCommandContext): void {
 		const node = this.resolveNode(context)
 		if (node) {
-			navigator.clipboard.writeText(node.path)
+			navigator.clipboard.writeText(this.getPath(node))
 		}
 	}
 
 	getLabel(context?: CopyPathCommandContext) {
 		return 'Copy Full Path'
+	}
+
+	getTooltip(context?: CopyPathCommandContext) {
+		const node = this.resolveNode(context)
+		if (node) {
+			return this.getPath(node)
+		}
 	}
 }
 
@@ -38,17 +49,28 @@ export class CopyRelativePathCommand extends WorkspaceCommand {
 		return this.resolveNode(context) != null
 	}
 
+	getPath(node: TreeNode): string {
+		const workspaceAbsolutePath = this.workspace.viewState.directoryView.root.path
+		const nodeAbsolutePath = node.path
+		const nodeRelativePath = nodeAbsolutePath.substring(workspaceAbsolutePath.length)
+		return nodeRelativePath
+	}
+
 	execute(context?: CopyPathCommandContext): void {
 		const node = this.resolveNode(context)
 		if (node) {
-			const workspaceAbsolutePath = this.workspace.viewState.directoryView.root.path
-			const nodeAbsolutePath = node.path
-			const nodeRelativePath = nodeAbsolutePath.substring(workspaceAbsolutePath.length)
-			navigator.clipboard.writeText(nodeRelativePath)
+			navigator.clipboard.writeText(this.getPath(node))
 		}
 	}
 
 	getLabel(context?: CopyPathCommandContext) {
 		return 'Copy Relative Path'
+	}
+	
+	getTooltip(context?: CopyPathCommandContext) {
+		const node = this.resolveNode(context)
+		if (node) {
+			return this.getPath(node)
+		}
 	}
 }

--- a/apps/tangent-electron/src/app/model/commands/CopyPath.ts
+++ b/apps/tangent-electron/src/app/model/commands/CopyPath.ts
@@ -7,7 +7,7 @@ interface CopyPathCommandContext extends CommandContext {
 }
 
 function copyTooltip(what: string): string {
-	return `Copies "${what}" to the clipboard`
+	return `Copies "${what}" to the clipboard.`
 }
 
 export class CopyAbsolutePathCommand extends WorkspaceCommand {


### PR DESCRIPTION
Hi, sometimes I wanna abuse the `copy path` command "to see path of current note/file". based on [Taylor's advice](https://github.com/suchnsuch/Tangent/pull/388#discussion_r3905450457) the tooltip should contain useful information, in this context I think seeing the path is useful

<img width="818" height="287" alt="image" src="https://github.com/user-attachments/assets/2fae7fae-836d-4998-aac5-648520fd6344" />

